### PR TITLE
task para colocar tarefas no cron

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,3 +29,13 @@ deploy_laravel_env:
   - name: APP_ENV
     value: "production"
 
+# task schedule vars to cron
+deploy_laravel_cron: false
+deploy_laravel_cron_name: "task scheduling"
+deploy_laravel_cron_job: "cd {{ deploy_laravel_dest}}{{ deploy_laravel_domain }}
+                          && php artisan schedule:run >> /dev/null 2>&1"
+deploy_laravel_cron_minute: "*"
+deploy_laravel_cron_hour: "*"
+deploy_laravel_cron_day: "*"
+deploy_laravel_cron_month: "*"
+deploy_laravel_cron_weekday: "*"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,11 +31,11 @@ deploy_laravel_env:
 
 # task schedule vars to cron
 deploy_laravel_cron: false
-deploy_laravel_cron_name: "task scheduling"
+deploy_laravel_cron_name: "task scheduling {{ deploy_laravel_domain }}"
 deploy_laravel_cron_job: "cd {{ deploy_laravel_dest}}{{ deploy_laravel_domain }}
                           && php artisan schedule:run >> /dev/null 2>&1"
-deploy_laravel_cron_minute: "*"
-deploy_laravel_cron_hour: "*"
+deploy_laravel_cron_minute: "0"
+deploy_laravel_cron_hour: "0,6,12,18"
 deploy_laravel_cron_day: "*"
 deploy_laravel_cron_month: "*"
 deploy_laravel_cron_weekday: "*"

--- a/tasks/cron.yml
+++ b/tasks/cron.yml
@@ -1,0 +1,9 @@
+- name: add cron task scheduling
+  cron:
+    job: "{{ deploy_laravel_cron_job }}"
+    name: "{{ deploy_laravel_cron_name }}"
+    minute: "{{ deploy_laravel_cron_minute }}"
+    hour: "{{ deploy_laravel_cron_hour }}"
+    day: "{{ deploy_laravel_cron_day }}"
+    month: "{{ deploy_laravel_cron_month }}"
+    weekday: "{{ deploy_laravel_cron_weekday }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,3 +7,6 @@
 - import_tasks: assets.yml
 - import_tasks: owner.yml
 - import_tasks: cache.yml
+- import_tasks: cron.yml
+  when: deploy_laravel_cron
+


### PR DESCRIPTION
    Essa task coloca o comando para rodar as tarefas agendadas dos
    sistemas no cron.
    Para ativá-la é necesssário colocar a variável
    "deploy_laravel_cron: true" no playbook do mesmo.

fix #8;